### PR TITLE
Bugfix/8 gtest diagnostics parser

### DIFF
--- a/lua/neotest-ctest/framework/gtest/init.lua
+++ b/lua/neotest-ctest/framework/gtest/init.lua
@@ -25,7 +25,7 @@ function gtest.parse_errors(output)
   -- NOTE: This is a very hacky solution to transform gtest <v1.14.0 to a v.14.0+ formatted error message output
   local tmp = ""
   for str in string.gmatch(capture, "[^\r\n$]+") do
-    local line = string.match(str, ".-:(%d):%sFailure")
+    local line = string.match(str, ".-:(%d+):%sFailure")
     if line then
       tmp = tmp .. "\n\n" .. str
     else
@@ -39,7 +39,7 @@ function gtest.parse_errors(output)
   local errors = {}
 
   for failures in string.gmatch(capture .. "\n\n", "(.-)[\r\n][\r\n]") do
-    for line, message in string.gmatch(failures, ".-:(%d):%sFailure[\r\n](.+)") do
+    for line, message in string.gmatch(failures, ".-:(%d+):%sFailure[\r\n](.+)") do
       table.insert(errors, { line = tonumber(line), message = message })
     end
   end

--- a/tests/unit/gtest_spec.lua
+++ b/tests/unit/gtest_spec.lua
@@ -104,7 +104,7 @@ end)
 
 describe("gtest.parse_errors", function()
   it("parses gtest >= v1.14.0 diagnostics correctly", function()
-    -- NOTE: Partial GTest output (only the relevant portions are included
+    -- NOTE: Partial GTest output (only the relevant portions are included)
     local output = [[
 [ RUN      ] Suite.Second
 /path/to/TEST_test.cpp:8: Failure
@@ -136,7 +136,7 @@ Expected: true
   end)
 
   it("parses gtest < v1.14.0 diagnostics correctly", function()
-    -- NOTE: Partial GTest output (only the relevant portions are included
+    -- NOTE: Partial GTest output (only the relevant portions are included)
     local output = [[
 [ RUN      ] Suite.Second
 /path/to/TEST_test.cpp:8: Failure


### PR DESCRIPTION
Resolves #8 

A workaround for handling gtest < v1.14.0 diagnostic error messages.