### PR TITLE
fix diagnostics for Windows

### DIFF
--- a/lua/neotest-ctest/framework/catch2.lua
+++ b/lua/neotest-ctest/framework/catch2.lua
@@ -55,8 +55,9 @@ function catch2.parse_errors(output)
 
   local errors = {}
 
-  for failures in string.gmatch(capture .. "\n\n", "(.-)[\r\n][\r\n]") do
-    for line, message in string.gmatch(failures, ".-:(%d+):%sFAILED%:[\r\n](.+)") do
+  for failures in string.gmatch(capture .. "\n\n", "(.-)\n\n") do
+    print("failures" .. failures)
+    for line, message in string.gmatch(failures, ".-[:%(](%d+)%)-:%sFAILED:[\r\n]+(.+)") do
       table.insert(errors, { line = tonumber(line), message = message })
     end
   end

--- a/lua/neotest-ctest/framework/doctest.lua
+++ b/lua/neotest-ctest/framework/doctest.lua
@@ -56,8 +56,8 @@ function doctest.parse_errors(output)
 
   local errors = {}
 
-  for failures in string.gmatch(capture .. "\n\n", "(.-)[\r\n][\r\n]") do
-    for line, message in string.gmatch(failures, ".-:(%d+):%sERROR%:[%s]?(.+)") do
+  for failures in string.gmatch(capture .. "\n\n", "(.-)\n\n") do
+    for line, message in string.gmatch(failures, ".-[:%(](%d+)%)-:%sERROR:[%s]?(.+)") do
       table.insert(errors, { line = tonumber(line), message = message })
     end
   end

--- a/lua/neotest-ctest/framework/gtest.lua
+++ b/lua/neotest-ctest/framework/gtest.lua
@@ -54,10 +54,16 @@ function gtest.parse_errors(output)
 
   -- NOTE: At this point, the capture should be compatible with gtest v1.14.0+ (which is considerably easier to parse)
   local errors = {}
+  local matches = {
+    ".-:(%d+):%sFailure[\r\n](.+)", -- Unix matcher
+    ".-%((%d+)%):%serror:(.+)",     -- Windows matcher
+  }
 
-  for failures in string.gmatch(capture .. "\n\n", "(.-)[\r\n][\r\n]") do
-    for line, message in string.gmatch(failures, ".-:(%d+):%sFailure[\r\n](.+)") do
-      table.insert(errors, { line = tonumber(line), message = message })
+  for failures in string.gmatch(capture .. "\n\n", "(.-)\n\n") do
+    for _, match in ipairs(matches) do
+      for line, message in string.gmatch(failures, match) do
+        table.insert(errors, { line = tonumber(line), message = message })
+      end
     end
   end
 


### PR DESCRIPTION
* capture explicitly double `\n` instead of `[\r\n]` cause it captures only the first `\r\n`
 * fix line number capture
   - Windows : `D:/filepath/(10):`
   - Unix    : `/filepath:10:`
 * for some reason gtest on Windows dont use `Failure` keyword but
`error`. lua patterns don't allow `[Failure|error]` matching so we need
to double check it